### PR TITLE
Fix GitHub release workflow and Makefile typo

### DIFF
--- a/.github/workflows/github.release.yml
+++ b/.github/workflows/github.release.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           name: ${{ fromJson(env.manifest).version }}
           tag_name: '${{ fromJson(env.manifest).version }}'
-          generate_release_notes: null
+          generate_release_notes: true
           files: release.zip  

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ $(CHROME_BUILD_TIMESTAMP): $(SRC_FILES) $(MANIFEST)
 	@echo -e "$(GREEN)Done$(RESET)"
 
 .PHONY: build/edge
-buid/edge:  ## Build Edge extension zip (same as Chrome)
+build/edge:  ## Build Edge extension zip (same as Chrome)
 	$(MAKE) build/chrome
 
 .PHONY: clean


### PR DESCRIPTION
- Enable auto-generated release notes in github.release.yml
- Fix typo: buid/edge -> build/edge in Makefile