### PR TITLE
Fix Firefox release action invalid input

### DIFF
--- a/.github/workflows/firefox-release.yml
+++ b/.github/workflows/firefox-release.yml
@@ -27,6 +27,5 @@ jobs:
                 addon-guid: dblpSearch@fcalefato.dev
                 xpi-path: build/firefox/dblpSearch-addon-${{ fromJson(env.manifest).version }}.xpi
                 self-hosted: false
-                license: MIT
                 jwt-issuer: ${{ secrets.FIREFOX_API_KEY }}
                 jwt-secret: ${{ secrets.FIREFOX_API_SECRET }}


### PR DESCRIPTION
The wdzeng/firefox-addon action does not support a 'license' input. Valid inputs are: addon-guid, xpi-path, source-file-path, self-hosted, jwt-issuer, jwt-secret, approval-notes.